### PR TITLE
Added exponential placer cost function

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-10.15
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -19,7 +19,6 @@ if [[ "$OS" == "linux" ]]; then
     fi
 
 elif [[ "$OS" == "osx" ]]; then
-    export PNR_PLACER_EXP=1
     python --version
     cd thunder && CXX=g++-9 python setup.py bdist_wheel
     pip install dist/*.whl

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -19,6 +19,7 @@ if [[ "$OS" == "linux" ]]; then
     fi
 
 elif [[ "$OS" == "osx" ]]; then
+    export PNR_PLACER_EXP=1
     python --version
     cd thunder && CXX=g++-9 python setup.py bdist_wheel
     pip install dist/*.whl

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -282,7 +282,7 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
     char* dist_exp = std::getenv("PNR_PLACER_EXP");
-    if (dist_exp != nullptr) {
+    if (!dist_exp) {
         exp = std::stoi(dist_exp);
     }
     this->placer_cost_exp = exp;

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -282,6 +282,7 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
     char* dist_exp = std::getenv("PNR_PLACER_EXP");
+    std::cout << dist_exp << std::endl;
     //if (dist_exp != nullptr) {
     //    exp = std::stoi(dist_exp);
     //}

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -282,10 +282,9 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
     char* dist_exp = std::getenv("PNR_PLACER_EXP");
-    std::cout << dist_exp << std::endl;
-    //if (dist_exp != nullptr) {
-    //    exp = std::stoi(dist_exp);
-    //}
+    if (dist_exp != nullptr) {
+        exp = std::stoi(dist_exp);
+    }
     this->placer_cost_exp = exp;
 }
 

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -281,9 +281,8 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
-    char* dist_exp = std::getenv("PNR_PLACER_EXP");
-    if (dist_exp != NULL) {
-        exp = std::stoi(dist_exp);
+    if (std::getenv("PNR_PLACER_EXP")) {
+        exp = std::stoi(std::getenv("PNR_PLACER_EXP"));
     }
     this->placer_cost_exp = exp;
 }

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -281,9 +281,10 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
-    if (std::getenv("PNR_PLACER_EXP")) {
-        exp = std::stoi(std::getenv("PNR_PLACER_EXP"));
-    }
+    char* dist_exp = std::getenv("PNR_PLACER_EXP");
+    //if (dist_exp != nullptr) {
+    //    exp = std::stoi(dist_exp);
+    //}
     this->placer_cost_exp = exp;
 }
 

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -282,7 +282,7 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
     char* dist_exp = std::getenv("PNR_PLACER_EXP");
-    if (dist_exp != NULL) {
+    if (dist_exp != nullptr) {
         exp = std::stoi(dist_exp);
     }
     this->placer_cost_exp = exp;

--- a/thunder/src/detailed.cc
+++ b/thunder/src/detailed.cc
@@ -282,7 +282,7 @@ void DetailedPlacer::set_fold_reg(const ::vector<::string> &cluster_blocks,
 void DetailedPlacer::set_placer_cost_exp() {
     int exp = 1;
     char* dist_exp = std::getenv("PNR_PLACER_EXP");
-    if (!dist_exp) {
+    if (dist_exp != NULL) {
         exp = std::stoi(dist_exp);
     }
     this->placer_cost_exp = exp;

--- a/thunder/src/detailed.hh
+++ b/thunder/src/detailed.hh
@@ -48,6 +48,7 @@ protected:
     std::map<char, std::pair<uint64_t, uint64_t>> instance_type_index_;
     char clb_type_;
     bool fold_reg_;
+    int placer_cost_exp;
 
     randutils::random_generator<std::mt19937> detail_rand_;
 
@@ -79,6 +80,8 @@ private:
     // will speed up a lot if there is no registers
     void set_fold_reg(const std::vector<std::string> &cluster_blocks,
                       bool fold_reg);
+
+    void set_placer_cost_exp();
 
     void compute_reg_no_pos(const std::vector<std::string> &cluster_blocks,
                             std::map<std::string,

--- a/thunder/src/util.cc
+++ b/thunder/src/util.cc
@@ -26,7 +26,8 @@ std::ostream& operator<<(std::ostream& os, const Point &p) {
 }
 
 double get_hpwl(const ::vector<Net> &netlist,
-                const ::vector<Instance> &instances) {
+                const ::vector<Instance> &instances,
+                int placer_cost_exp) {
     double hpwl = 0;
     for (auto const &net : netlist) {
         int xmin = INT_MAX;
@@ -44,12 +45,7 @@ double get_hpwl(const ::vector<Net> &netlist,
             if (pos.y > ymax)
                 ymax = pos.y;
         }
-        int exp = 1;
-        char* dist_exp = std::getenv("PNR_PLACER_EXP");
-        if (dist_exp != NULL) {
-            exp = std::stoi(dist_exp);
-        }
-        hpwl += std::pow((xmax - xmin) + (ymax - ymin), exp);
+        hpwl += std::pow((xmax - xmin) + (ymax - ymin), placer_cost_exp);
     }
     return hpwl;
 }

--- a/thunder/src/util.cc
+++ b/thunder/src/util.cc
@@ -44,7 +44,12 @@ double get_hpwl(const ::vector<Net> &netlist,
             if (pos.y > ymax)
                 ymax = pos.y;
         }
-        hpwl += (xmax - xmin) + (ymax - ymin);
+        int exp = 1;
+        char* dist_exp = std::getenv("PNR_PLACER_EXP");
+        if (dist_exp != NULL) {
+            exp = std::stoi(dist_exp);
+        }
+        hpwl += std::pow((xmax - xmin) + (ymax - ymin), exp);
     }
     return hpwl;
 }

--- a/thunder/src/util.hh
+++ b/thunder/src/util.hh
@@ -54,7 +54,8 @@ struct Net {
 };
 
 double get_hpwl(const std::vector<Net> &netlist,
-                const std::vector<Instance> &instances);
+                const std::vector<Instance> &instances,
+                int placer_cost_exp);
 
 std::map<std::string, std::vector<std::string>> group_reg_nets(
         std::map<std::string, std::vector<std::string>> &netlist);


### PR DESCRIPTION
Some very congested applications have trouble routing using the default placer hpwl cost function. This branch allows the user to set the environmental variable PNR_PLACER_EXP, which will change the cost function to exp(hpwl, PNR_PLACER_EXP). In my tests, setting this value to a value greater than 1 significantly reduces the routing issues in congested apps.